### PR TITLE
Fix player scoring sequence

### DIFF
--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -100,10 +100,15 @@ export const useGameState = (gameId) => {
   
   const updatePlayerScore = useCallback((playerId) => {
     if (!gameState || !isCaptain) return;
+    // Gateball scoring sequence progresses through 1, 2, 3 and 5.
+    // After reaching 5, the score should not increase further.
     const scoreSequence = [0, 1, 2, 3, 5];
     const currentScore = gameState.scores[playerId];
     const currentIndex = scoreSequence.indexOf(currentScore);
-    const nextIndex = currentIndex === -1 ? 1 : (currentIndex + 1) % scoreSequence.length;
+    const nextIndex =
+      currentIndex === -1
+        ? 1
+        : Math.min(currentIndex + 1, scoreSequence.length - 1);
     const newScore = scoreSequence[nextIndex];
 
     const newScores = { ...gameState.scores, [playerId]: newScore };


### PR DESCRIPTION
## Summary
- ensure player scores progress 1→2→3→5 and stop at 5

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c64f11ee48328a2f652e676e2fad5