### PR TITLE
Adjust scoring sequence

### DIFF
--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -100,9 +100,18 @@ export const useGameState = (gameId) => {
   
   const updatePlayerScore = useCallback((playerId) => {
     if (!gameState || !isCaptain) return;
+    const scoreSequence = [1, 2, 3, 5];
     const currentScore = gameState.scores[playerId];
-    const newScore = currentScore >= 8 ? 0 : currentScore + 1;
-    
+    let newScore;
+
+    if (currentScore === 5) {
+      newScore = 0; // reset after reaching 5
+    } else {
+      const currentIndex = scoreSequence.indexOf(currentScore);
+      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % scoreSequence.length;
+      newScore = scoreSequence[nextIndex];
+    }
+
     const newScores = { ...gameState.scores, [playerId]: newScore };
     const newState = { ...gameState, scores: newScores };
     updateRemoteState(newState);


### PR DESCRIPTION
## Summary
- ensure scoring resets to 0 after reaching 5

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c624b85bc8328ae86cf96cb890f7f