### PR TITLE
Add scroll to game lists

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,8 @@
 }
 
 body {
-  @apply bg-gray-900 text-white overflow-hidden;
+  @apply bg-gray-900 text-white;
+  overflow-x: hidden;
   font-family: 'Roboto', sans-serif;
   user-select: none;
   -webkit-user-select: none;
@@ -89,5 +90,6 @@ body {
 html, body, #root {
   height: 100vh;
   height: 100dvh;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -106,7 +106,7 @@ const LobbyScreen = () => {
 
         <div>
           <h2 className="text-2xl font-semibold mb-4">Jogos Ativos</h2>
-          <div className="bg-gray-800/50 rounded-lg p-4 min-h-[200px]">
+          <div className="bg-gray-800/50 rounded-lg p-4 min-h-[200px] max-h-[60vh] overflow-y-auto">
             {loading ? (
               <p className="text-center text-gray-400">Carregando jogos...</p>
             ) : games.length === 0 ? (
@@ -146,7 +146,7 @@ const LobbyScreen = () => {
 
         <div className="mt-8">
           <h2 className="text-2xl font-semibold mb-4">Jogos Finalizados</h2>
-          <div className="bg-gray-800/50 rounded-lg p-4 min-h-[200px]">
+          <div className="bg-gray-800/50 rounded-lg p-4 min-h-[200px] max-h-[60vh] overflow-y-auto">
             {loading ? (
               <p className="text-center text-gray-400">Carregando jogos...</p>
             ) : finishedGames.length === 0 ? (


### PR DESCRIPTION
## Summary
- make body and root containers scrollable
- limit game lists to 60vh and enable overflow scrolling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c748809b48328aefb51601bcff89c

## Resumo por Sourcery

Habilita a rolagem vertical no contêiner da página principal e restringe os painéis da lista de jogos para melhorar a usabilidade.

Melhorias:
- Permite a rolagem vertical nos contêineres body, html e root, ajustando as configurações de overflow
- Restringe as listas de jogos ativos e finalizados a uma altura máxima de 60vh com rolagem overflow-y

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable vertical scrolling on the main page container and constrain game list panels to improve usability.

Enhancements:
- Allow vertical scrolling on the body, html, and root containers by adjusting overflow settings
- Restrict active and finished game lists to a 60vh maximum height with overflow-y scrolling

</details>