### PR TITLE
Add account management screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import GameScreen from '@/components/GameScreen.jsx';
 import AuthScreen from '@/screens/AuthScreen';
 import LobbyScreen from '@/screens/LobbyScreen';
 import ManageTeamScreen from '@/screens/ManageTeamScreen';
+import AccountScreen from '@/screens/AccountScreen.jsx';
 import PrivacyPolicy from '@/pages/PrivacyPolicy.jsx';
 import TermsOfService from '@/pages/TermsOfService.jsx';
 import ProtectedRoute from '@/components/ProtectedRoute';
@@ -42,11 +43,19 @@ function App() {
                 </ProtectedRoute>
               }
             />
-             <Route
+            <Route
               path="/team/:teamId"
               element={
                 <ProtectedRoute>
                   <ManageTeamScreen />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/account"
+              element={
+                <ProtectedRoute>
+                  <AccountScreen />
                 </ProtectedRoute>
               }
             />

--- a/src/screens/AccountScreen.jsx
+++ b/src/screens/AccountScreen.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { supabase } from '@/lib/customSupabaseClient';
+import { useAuth } from '@/contexts/SupabaseAuthContext.jsx';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { motion } from 'framer-motion';
+import { useToast } from '@/components/ui/use-toast';
+import Footer from '@/components/Footer.jsx';
+
+const AccountScreen = () => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleChangePassword = async (e) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      toast({ variant: 'destructive', title: 'As senhas não coincidem' });
+      return;
+    }
+
+    setLoading(true);
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: user.email,
+      password: currentPassword,
+    });
+
+    if (signInError) {
+      toast({ variant: 'destructive', title: 'Senha atual incorreta', description: signInError.message });
+      setLoading(false);
+      return;
+    }
+
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+    if (error) {
+      toast({ variant: 'destructive', title: 'Erro ao atualizar senha', description: error.message });
+    } else {
+      toast({ title: 'Senha atualizada com sucesso' });
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <div className="min-h-screen bg-gradient-to-br from-gray-800 via-gray-900 to-black flex items-center justify-center p-4">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="w-full max-w-md p-8 space-y-6 bg-gray-800 rounded-xl shadow-2xl"
+        >
+          <div className="text-center">
+            <h1 className="text-3xl font-bold text-white">Gerenciar Conta</h1>
+          </div>
+          <form onSubmit={handleChangePassword} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="currentPassword" className="text-gray-300">Senha Atual</Label>
+              <Input
+                id="currentPassword"
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                required
+                className="bg-gray-700 border-gray-600 text-white focus:ring-yellow-400"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="newPassword" className="text-gray-300">Nova Senha</Label>
+              <Input
+                id="newPassword"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                required
+                className="bg-gray-700 border-gray-600 text-white focus:ring-yellow-400"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword" className="text-gray-300">Confirmar Nova Senha</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className="bg-gray-700 border-gray-600 text-white focus:ring-yellow-400"
+              />
+            </div>
+            <Button type="submit" className="w-full bg-yellow-500 hover:bg-yellow-600 text-black font-bold" disabled={loading}>
+              {loading ? 'Carregando...' : 'Alterar Senha'}
+            </Button>
+          </form>
+        </motion.div>
+      </div>
+      <Footer />
+    </>
+  );
+};
+
+export default AccountScreen;

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -6,7 +6,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useToast } from '@/components/ui/use-toast';
 import { supabase } from '@/lib/customSupabaseClient';
 import { useNavigate } from 'react-router-dom';
-import { Users, LogOut, Trash2 } from 'lucide-react';
+import { Users, LogOut, Trash2, Settings } from 'lucide-react';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import CreateGameDialog from '@/components/CreateGameDialog';
 import ManageTeamsDialog from '@/components/ManageTeamsDialog';
@@ -87,9 +87,14 @@ const LobbyScreen = () => {
       >
         <header className="flex justify-between items-center mb-8">
           <h1 className="text-3xl font-bold">Bem-vindo, {user?.email?.split('@')[0] || 'Jogador'}!</h1>
-          <Button onClick={signOut} variant="ghost" className="text-red-400 hover:text-red-500 hover:bg-red-900/20">
-            <LogOut className="mr-2 h-4 w-4" /> Sair
-          </Button>
+          <div className="flex gap-2">
+            <Button onClick={() => navigate('/account')} variant="ghost" className="text-gray-300 hover:text-white">
+              <Settings className="mr-2 h-4 w-4" /> Conta
+            </Button>
+            <Button onClick={signOut} variant="ghost" className="text-red-400 hover:text-red-500 hover:bg-red-900/20">
+              <LogOut className="mr-2 h-4 w-4" /> Sair
+            </Button>
+          </div>
         </header>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">


### PR DESCRIPTION
## Summary
- allow users to change password through new account management screen
- add navigation button in lobby header
- register new `/account` route

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d082479188328a57d4d6c0634102d

## Resumo por Sourcery

Adiciona uma nova tela de gerenciamento de conta para atualizações de senha e a conecta ao aplicativo registrando a rota e adicionando um botão de navegação

Novas funcionalidades:
- Introduz AccountScreen para que os usuários alterem sua senha com validação do lado do cliente e notificações toast
- Registra uma nova rota protegida `/account` no roteador do aplicativo

Melhorias:
- Adiciona um botão de configurações "Conta" ao cabeçalho do lobby para navegação rápida para a tela de gerenciamento de conta

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new account management screen for password updates and wire it into the app by registering the route and adding a navigation button

New Features:
- Introduce AccountScreen for users to change their password with client-side validation and toast notifications
- Register a new protected `/account` route in the application router

Enhancements:
- Add a "Conta" settings button to the lobby header for quick navigation to the account management screen

</details>