### PR TITLE
Implement game status flow

### DIFF
--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -20,7 +20,7 @@ const Timer = ({ timeLeft, gameState, onClick }) => {
       case 'countdown': return 'Preparando...';
       case 'running': return 'Em andamento';
       case 'paused': return 'Pausado';
-      case 'finished': return 'Finalizado';
+      case 'completed': return 'Finalizado';
       default: return '';
     }
   }

--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -23,9 +23,14 @@ export const useGameState = (gameId) => {
   } : { red: 0, white: 0 };
 
   const updateRemoteState = useCallback(async (newState) => {
+    const summaryStatus =
+      newState.status === 'completed' || newState.status === 'deleted'
+        ? newState.status
+        : 'lobby';
+
     const { error } = await supabase
       .from('games')
-      .update({ game_state: newState })
+      .update({ game_state: newState, status: summaryStatus })
       .eq('id', gameId);
     
     if (error) {
@@ -36,7 +41,7 @@ export const useGameState = (gameId) => {
 
   const finishGame = useCallback(async () => {
     if (!gameState || !isCaptain) return;
-    const finishedState = { ...gameState, status: 'finished' };
+    const finishedState = { ...gameState, status: 'completed' };
     
     const { data: gameData } = await supabase
       .from('games')
@@ -192,7 +197,7 @@ export const useGameState = (gameId) => {
              if (isCaptain) {
                 finishGame();
              }
-             return { ...prev, status: 'finished' };
+             return { ...prev, status: 'completed' };
           }
           return prev;
         });

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -35,8 +35,8 @@ const LobbyScreen = () => {
         setGames([]);
         setFinishedGames([]);
       } else {
-        setGames((gameData || []).filter(g => g.status !== 'finished'));
-        setFinishedGames((gameData || []).filter(g => g.status === 'finished'));
+        setGames((gameData || []).filter(g => g.status !== 'completed' && g.status !== 'deleted'));
+        setFinishedGames((gameData || []).filter(g => g.status === 'completed'));
       }
 
     } catch (error) {
@@ -64,7 +64,10 @@ const LobbyScreen = () => {
   const handleDeleteGame = async () => {
     if (!deleteGameId) return;
     try {
-      const { error } = await supabase.from('games').delete().eq('id', deleteGameId);
+      const { error } = await supabase
+        .from('games')
+        .update({ status: 'deleted' })
+        .eq('id', deleteGameId);
       if (error) throw error;
       toast({ title: 'Jogo removido com sucesso' });
     } catch (error) {


### PR DESCRIPTION
## Summary
- keep `games.status` as `lobby` while active
- mark completed games with `completed`
- mark deleted games with `deleted`
- filter game lists by new status values

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d1f59c46c8328897b108b1a146b4c