### PR TITLE
Add cancel button on account screen

### DIFF
--- a/src/screens/AccountScreen.jsx
+++ b/src/screens/AccountScreen.jsx
@@ -6,10 +6,12 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { motion } from 'framer-motion';
 import { useToast } from '@/components/ui/use-toast';
+import { useNavigate } from 'react-router-dom';
 
 const AccountScreen = () => {
   const { user } = useAuth();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -94,6 +96,14 @@ const AccountScreen = () => {
             </div>
             <Button type="submit" className="w-full bg-yellow-500 hover:bg-yellow-600 text-black font-bold" disabled={loading}>
               {loading ? 'Carregando...' : 'Alterar Senha'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => navigate(-1)}
+              className="w-full"
+            >
+              Cancelar
             </Button>
           </form>
         </motion.div>


### PR DESCRIPTION
## Summary
- allow returning to the previous page from the account management screen

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d247e8cb08328ad86f8d5ca73e7a4

## Resumo por Sourcery

Novos Recursos:
- Adiciona um botão Cancelar à tela da conta que leva o usuário de volta à página anterior

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add a Cancel button to the account screen that navigates the user back to the previous page

</details>