### PR TITLE
Prevent screen from sleeping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cmdk": "^0.2.0",
         "framer-motion": "^10.16.4",
         "lucide-react": "^0.285.0",
+        "nosleep.js": "^0.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
@@ -7881,6 +7882,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nosleep.js": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nosleep.js/-/nosleep.js-0.12.0.tgz",
+      "integrity": "sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cmdk": "^0.2.0",
     "framer-motion": "^10.16.4",
     "lucide-react": "^0.285.0",
+    "nosleep.js": "^0.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
@@ -50,5 +51,4 @@
     "tailwindcss": "^3.3.3",
     "terser": "^5.39.0",
     "vite": "^4.4.5"
-  }
-}
+  }}

--- a/src/hooks/useWakeLock.js
+++ b/src/hooks/useWakeLock.js
@@ -1,16 +1,30 @@
 import { useEffect, useRef } from 'react';
+import NoSleep from 'nosleep.js';
 
 export const useWakeLock = (isActive) => {
   const wakeLockRef = useRef(null);
+  const noSleepRef = useRef(null);
 
   useEffect(() => {
     const requestWakeLock = async () => {
-      if (isActive && 'wakeLock' in navigator) {
+      if (!isActive) return;
+
+      if ('wakeLock' in navigator) {
         try {
           wakeLockRef.current = await navigator.wakeLock.request('screen');
           console.log('Wake Lock ativado.');
         } catch (err) {
           console.error(`${err.name}, ${err.message}`);
+        }
+      } else {
+        try {
+          if (!noSleepRef.current) {
+            noSleepRef.current = new NoSleep();
+          }
+          noSleepRef.current.enable();
+          console.log('NoSleep habilitado.');
+        } catch (err) {
+          console.error('Erro ao habilitar NoSleep:', err);
         }
       }
     };
@@ -20,6 +34,11 @@ export const useWakeLock = (isActive) => {
         wakeLockRef.current.release();
         wakeLockRef.current = null;
         console.log('Wake Lock liberado.');
+      }
+      if (noSleepRef.current) {
+        noSleepRef.current.disable();
+        noSleepRef.current = null;
+        console.log('NoSleep desabilitado.');
       }
     };
 
@@ -41,5 +60,4 @@ export const useWakeLock = (isActive) => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       document.removeEventListener('fullscreenchange', handleVisibilityChange);
     };
-  }, [isActive]);
-};
+  }, [isActive]);};


### PR DESCRIPTION
## Summary
- prevent screen from turning off on unsupported devices by adding NoSleep fallback
- add `nosleep.js` dependency

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686db28bdbe48328a2dbe6ff9b6e1c66

## Resumo por Sourcery

Impede que a tela hiberne em dispositivos não suportados, integrando um fallback NoSleep no hook `useWakeLock` e adicionando a dependência `nosleep.js`.

Novos Recursos:
- Adiciona fallback NoSleep para manter a tela ativa quando a API Wake Lock não estiver disponível

Melhorias:
- Atualiza o hook `useWakeLock` para ativar e desativar o NoSleep juntamente com o wake lock nativo

Build:
- Adiciona `nosleep.js` como uma dependência do projeto

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent the screen from sleeping on unsupported devices by integrating a NoSleep fallback in the useWakeLock hook and adding the nosleep.js dependency.

New Features:
- Add NoSleep fallback to keep the screen awake when the Wake Lock API is unavailable

Enhancements:
- Update useWakeLock hook to enable and disable NoSleep alongside the native wake lock

Build:
- Add nosleep.js as a project dependency

</details>