### PR TITLE
Fix mobile header overflow

### DIFF
--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -86,9 +86,11 @@ const LobbyScreen = () => {
         animate={{ opacity: 1, y: 0 }}
         className="w-full max-w-4xl p-6"
       >
-        <header className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold">Bem-vindo, {user?.email?.split('@')[0] || 'Jogador'}!</h1>
-          <div className="flex gap-2">
+        <header className="flex flex-col sm:flex-row justify-between items-center gap-2 mb-8">
+          <h1 className="text-3xl font-bold text-center sm:text-left break-words">
+            Bem-vindo, {user?.email?.split('@')[0] || 'Jogador'}!
+          </h1>
+          <div className="flex gap-2 flex-shrink-0">
             <Button onClick={() => navigate('/account')} variant="ghost" className="text-gray-300 hover:text-white">
               <Settings className="mr-2 h-4 w-4" /> Conta
             </Button>


### PR DESCRIPTION
## Summary
- adjust header in LobbyScreen to wrap on small screens and avoid overflow

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fe75e4f9883289911702616eb4a8b