### PR TITLE
Use audio segments for game timer

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -54,7 +54,10 @@ const GameScreen = () => {
     if (now - lastTapTime < 300) {
       setShowConfirmDialog(true);
     } else {
-      if (status === 'lobby' || status === 'paused') {
+      if (status === 'lobby') {
+        await playSound('parte1');
+        startGame();
+      } else if (status === 'paused') {
         startGame();
       } else if (status === 'running') {
         pauseGame();
@@ -84,10 +87,15 @@ const GameScreen = () => {
     if (status === 'running' && isAudioInitialized) {
       const minutes = Math.floor(timeLeft / 60);
       const seconds = timeLeft % 60;
-      
+      const elapsed = 1800 - timeLeft;
+
+      if (elapsed === 900) playSound('parte2');
+      if (elapsed === 1200) playSound('parte3');
+      if (elapsed === 1500) playSound('parte4');
+      if (timeLeft === 0) playSound('parte5');
+
       if (seconds === 0 && [15, 10, 5, 2, 1].includes(minutes)) playSound('alert');
       if (timeLeft <= 10 && timeLeft > 0) playSound('beep');
-      if (timeLeft === 0) playSound('gameEnd');
     }
   }, [timeLeft, status, isAudioInitialized, playSound]);
 

--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -63,25 +63,10 @@ export const useGameState = (gameId) => {
   
   const startGame = useCallback(() => {
     if (!gameState || (gameState.status !== 'lobby' && gameState.status !== 'paused') || !isCaptain) return;
-    
-    let countdown = 5;
-    const newStatus = gameState.status === 'lobby' ? 'countdown' : 'running';
-    const tempState = { ...gameState, status: newStatus };
-    setGameState(tempState);
-    
-    if (newStatus === 'countdown') {
-      const countdownInterval = setInterval(() => {
-        countdown--;
-        if (countdown <= 0) {
-          clearInterval(countdownInterval);
-          const runningState = { ...tempState, status: 'running' };
-          setGameState(runningState);
-          updateRemoteState(runningState);
-        }
-      }, 1000);
-    } else {
-        updateRemoteState(tempState);
-    }
+
+    const newState = { ...gameState, status: 'running' };
+    setGameState(newState);
+    updateRemoteState(newState);
   }, [gameState, updateRemoteState, isCaptain]);
 
   const pauseGame = useCallback(() => {


### PR DESCRIPTION
## Summary
- add HTML audio loading and playback in `useAudioManager`
- play `Parte-1` before starting a game
- schedule `Parte-2` through `Parte-5` at 15, 20, 25 and 30 minutes
- simplify `startGame` implementation

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68719c680ce88328ba1720e7f26ba4b5