### PR TITLE
Fix mobile layout for game screen

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -110,8 +110,8 @@ const GameScreen = () => {
 
   return (
     <>
-    <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-4 gap-4">
-      <div className="flex gap-4 h-20">
+    <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-4">
+      <div className="flex gap-2 sm:gap-4 h-16 sm:h-20">
         <TeamScore team="red" score={teamScores.red} label="EQUIPE VERMELHA" />
         <TeamScore team="white" score={teamScores.white} label="EQUIPE BRANCA" />
       </div>
@@ -120,7 +120,7 @@ const GameScreen = () => {
         <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimerClick} />
       </div>
 
-      <div className="grid grid-cols-5 grid-rows-2 gap-3 h-32">
+      <div className="grid grid-cols-5 grid-rows-2 gap-2 sm:gap-3 h-28 sm:h-32">
         {playerScores && Object.keys(playerScores).map((pId) => {
           const playerId = parseInt(pId, 10);
           return (
@@ -136,7 +136,7 @@ const GameScreen = () => {
       </div>
 
       {isCaptain && (
-        <div className="flex justify-center gap-4 h-12">
+        <div className="flex justify-center gap-2 sm:gap-4 h-10 sm:h-12">
           <Button variant="outline" size="sm" onClick={handleTimerClick} className="bg-gray-800 border-gray-600 text-white hover:bg-gray-700">
             {status === 'running' ? <><Pause className="w-4 h-4 mr-2" /> Pausar</> : <><Play className="w-4 h-4 mr-2" /> Iniciar</>}
           </Button>

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -37,7 +37,7 @@ const Timer = ({ timeLeft, gameState, onClick }) => {
       <div className="absolute inset-0 rounded-full bg-yellow-400 opacity-20 blur-xl animate-pulse" />
       
       {/* Main timer circle */}
-      <div className="relative w-80 h-80 flex items-center justify-center">
+      <div className="relative w-64 h-64 sm:w-80 sm:h-80 flex items-center justify-center">
         {/* Background circle */}
         <svg className="absolute w-full h-full transform -rotate-90" viewBox="0 0 320 320">
           <circle


### PR DESCRIPTION
## Summary
- tweak spacing and sizing for GameScreen
- make timer component smaller on small screens

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68719f35ee908328b559ea33919c0621

## Resumo por Sourcery

Melhora a responsividade móvel da tela do jogo e do temporizador, ajustando o preenchimento do contêiner, os espaçamentos entre os elementos e as dimensões dos componentes em breakpoints pequenos.

Melhorias:
- Refina o layout do GameScreen ajustando o preenchimento, o espaçamento e as alturas dos elementos para viewports móveis
- Redimensiona o componente Timer para telas pequenas, reduzindo sua largura e altura em breakpoints sm

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve mobile responsiveness of the game screen and timer by adjusting container padding, element gaps, and component dimensions at small breakpoints.

Enhancements:
- Refine GameScreen layout by adjusting padding, gap spacing, and element heights for mobile viewports
- Resize Timer component for small screens by reducing its width and height at sm breakpoints

</details>