### PR TITLE
Implement wake lock on user interaction

### DIFF
--- a/src/hooks/useWakeLock.js
+++ b/src/hooks/useWakeLock.js
@@ -4,6 +4,7 @@ import NoSleep from 'nosleep.js';
 export const useWakeLock = (isActive) => {
   const wakeLockRef = useRef(null);
   const noSleepRef = useRef(null);
+  const interactionRequestedRef = useRef(false);
 
   useEffect(() => {
     const requestWakeLock = async () => {
@@ -42,8 +43,21 @@ export const useWakeLock = (isActive) => {
       }
     };
 
+    const handleUserInteraction = () => {
+      requestWakeLock();
+      interactionRequestedRef.current = true;
+      document.removeEventListener('touchstart', handleUserInteraction);
+      document.removeEventListener('click', handleUserInteraction);
+    };
+
     if (isActive) {
       requestWakeLock();
+      if (!interactionRequestedRef.current) {
+        document.addEventListener('touchstart', handleUserInteraction, { once: true });
+        document.addEventListener('click', handleUserInteraction, { once: true });
+      }
+    } else {
+      interactionRequestedRef.current = false;
     }
 
     const handleVisibilityChange = () => {
@@ -57,6 +71,8 @@ export const useWakeLock = (isActive) => {
 
     return () => {
       releaseWakeLock();
+      document.removeEventListener('touchstart', handleUserInteraction);
+      document.removeEventListener('click', handleUserInteraction);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       document.removeEventListener('fullscreenchange', handleVisibilityChange);
     };


### PR DESCRIPTION
## Summary
- keep the phone screen awake during gameplay by requesting the Wake Lock API on the first user interaction

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871a9280538832881ceebff7d4081c6

## Resumo por Sourcery

Adia os pedidos de wake lock até a primeira interação do jogador e mantém o wake lock enquanto o jogo está ativo, com configuração e limpeza adequadas dos listeners de interação.

Novos Recursos:
- Mantém a tela ligada durante o jogo, solicitando um wake lock na primeira interação do usuário

Melhorias:
- Rastreia as solicitações de interação para evitar a adição de listeners de evento duplicados
- Remove os listeners de interação do usuário durante a limpeza

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delay wake lock requests until the player’s first interaction and maintain the wake lock while gameplay is active, with proper setup and cleanup of interaction listeners.

New Features:
- Keep the screen awake during gameplay by requesting a wake lock on first user interaction

Enhancements:
- Track interaction requests to prevent adding duplicate event listeners
- Remove user interaction listeners during cleanup

</details>