### PR TITLE
Implement visitor home screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/SupabaseAuthContext.jsx';
 import GameScreen from '@/components/GameScreen.jsx';
+import HomeScreen from '@/screens/HomeScreen.jsx';
 import AuthScreen from '@/screens/AuthScreen';
 import LobbyScreen from '@/screens/LobbyScreen';
 import ManageTeamScreen from '@/screens/ManageTeamScreen';
@@ -34,7 +35,7 @@ function App() {
       <Router>
         <GameProvider>
           <Routes>
-            <Route path="/auth" element={!session ? <AuthScreen /> : <Navigate to="/" />} />
+            <Route path="/auth" element={!session ? <AuthScreen /> : <Navigate to="/lobby" />} />
             <Route
               path="/game/:gameId"
               element={
@@ -62,14 +63,18 @@ function App() {
             <Route path="/privacy-policy" element={<PrivacyPolicy />} />
             <Route path="/terms-of-service" element={<TermsOfService />} />
             <Route
-              path="/"
+              path="/lobby"
               element={
                 <ProtectedRoute>
                   <LobbyScreen />
                 </ProtectedRoute>
               }
             />
-            <Route path="*" element={<Navigate to={session ? "/" : "/auth"} />} />
+            <Route
+              path="/"
+              element={session ? <Navigate to="/lobby" /> : <HomeScreen />} 
+            />
+            <Route path="*" element={<Navigate to={session ? "/lobby" : "/auth"} />} />
           </Routes>
         </GameProvider>
         <Footer />

--- a/src/hooks/useLocalGame.js
+++ b/src/hooks/useLocalGame.js
@@ -1,0 +1,66 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const initScores = () => {
+  const s = {};
+  for (let i = 1; i <= 10; i++) s[i] = 0;
+  return s;
+};
+
+export const useLocalGame = () => {
+  const [status, setStatus] = useState('lobby');
+  const [timeLeft, setTimeLeft] = useState(1800);
+  const [scores, setScores] = useState(initScores);
+  const timerRef = useRef(null);
+
+  const teamScores = {
+    red: Object.entries(scores).filter(([id]) => parseInt(id) % 2 === 1).reduce((s, [,v]) => s + v, 0),
+    white: Object.entries(scores).filter(([id]) => parseInt(id) % 2 === 0).reduce((s, [,v]) => s + v, 0)
+  };
+
+  const startGame = useCallback(() => {
+    if (status === 'lobby' || status === 'paused') setStatus('running');
+  }, [status]);
+
+  const pauseGame = useCallback(() => {
+    if (status === 'running') setStatus('paused');
+  }, [status]);
+
+  const resetGame = useCallback(() => {
+    setStatus('lobby');
+    setTimeLeft(1800);
+    setScores(initScores());
+  }, []);
+
+  const updatePlayerScore = useCallback((playerId) => {
+    const sequence = [1,2,3,5];
+    setScores(prev => {
+      const current = prev[playerId];
+      const next = current === 5 ? 0 : sequence[(sequence.indexOf(current) + 1) % sequence.length];
+      return { ...prev, [playerId]: next };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (status === 'running') {
+      timerRef.current = setInterval(() => {
+        setTimeLeft(t => (t > 0 ? t - 1 : 0));
+      }, 1000);
+    } else {
+      clearInterval(timerRef.current);
+    }
+    return () => clearInterval(timerRef.current);
+  }, [status]);
+
+  return {
+    loading: false,
+    error: null,
+    status,
+    timeLeft,
+    playerScores: scores,
+    teamScores,
+    startGame,
+    pauseGame,
+    resetGame,
+    updatePlayerScore,
+  };
+};

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Timer from '@/components/Timer';
+import PlayerScore from '@/components/PlayerScore';
+import TeamScore from '@/components/TeamScore';
+import { Button } from '@/components/ui/button';
+import { useLocalGame } from '@/hooks/useLocalGame';
+
+const HomeScreen = () => {
+  const navigate = useNavigate();
+  const {
+    status,
+    timeLeft,
+    playerScores,
+    teamScores,
+    startGame,
+    pauseGame,
+    resetGame,
+    updatePlayerScore
+  } = useLocalGame();
+
+  const handleTimer = () => {
+    if (status === 'running') pauseGame();
+    else startGame();
+  };
+
+  return (
+    <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-4">
+      <header className="flex justify-between items-center text-white mb-2">
+        <h1 className="text-xl font-bold">Gateball Timer</h1>
+        <Button variant="ghost" className="text-yellow-400" onClick={() => navigate('/auth')}>Equipe</Button>
+      </header>
+      <div className="flex gap-2 sm:gap-4 h-16 sm:h-20">
+        <TeamScore team="red" score={teamScores.red} label="EQUIPE VERMELHA" />
+        <TeamScore team="white" score={teamScores.white} label="EQUIPE BRANCA" />
+      </div>
+      <div className="flex-1 flex items-center justify-center">
+        <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimer} />
+      </div>
+      <div className="grid grid-cols-5 grid-rows-2 gap-2 sm:gap-3 h-28 sm:h-32">
+        {Object.keys(playerScores).map(pId => {
+          const id = parseInt(pId, 10);
+          return (
+            <PlayerScore
+              key={id}
+              playerId={id}
+              score={playerScores[id]}
+              isRedTeam={id % 2 === 1}
+              onClick={() => updatePlayerScore(id)}
+            />
+          );
+        })}
+      </div>
+      <div className="flex justify-center gap-2 sm:gap-4 h-10 sm:h-12">
+        <Button variant="outline" size="sm" onClick={handleTimer} className="bg-gray-800 border-gray-600 text-white hover:bg-gray-700">
+          {status === 'running' ? 'Pausar' : 'Iniciar'}
+        </Button>
+        <Button variant="outline" size="sm" onClick={resetGame} className="bg-gray-800 border-gray-600 text-white hover:bg-gray-700">
+          Reiniciar
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default HomeScreen;


### PR DESCRIPTION
## Summary
- add `HomeScreen` for guest users with simple local game state
- create `useLocalGame` hook for offline matches
- adjust routes in `App.jsx` so `/` loads visitor game and authenticated users access lobby at `/lobby`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871bf7dc9e88328b4a428f0953ab4d3