### PR TITLE
Fix audio initialization for guests

### DIFF
--- a/src/hooks/useAudioManager.js
+++ b/src/hooks/useAudioManager.js
@@ -1,5 +1,5 @@
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 
 export const useAudioManager = () => {
   const audioContextRef = useRef(null);
@@ -91,6 +91,22 @@ export const useAudioManager = () => {
         return Promise.resolve();
     }
   }, [generateBeep]);
+
+  useEffect(() => {
+    const handleInteraction = () => {
+      initializeAudio();
+    };
+
+    if (!isInitializedRef.current) {
+      document.addEventListener('touchstart', handleInteraction, { once: true });
+      document.addEventListener('click', handleInteraction, { once: true });
+    }
+
+    return () => {
+      document.removeEventListener('touchstart', handleInteraction);
+      document.removeEventListener('click', handleInteraction);
+    };
+  }, [initializeAudio]);
 
   return {
     initializeAudio,


### PR DESCRIPTION
## Summary
- trigger audio initialization on first interaction with the page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871c24418c08328b4f225543a84d720

## Resumo por Sourcery

Correções de Bugs:
- Inicializar o contexto de áudio na primeira interação de toque ou clique quando ainda não estiver inicializado

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Initialize audio context on first touch or click interaction when not already initialized

</details>