### PR TITLE
Implement logout redirect to home

### DIFF
--- a/src/contexts/SupabaseAuthContext.jsx
+++ b/src/contexts/SupabaseAuthContext.jsx
@@ -78,6 +78,8 @@ export const AuthProvider = ({ children }) => {
         title: "Sign out Failed",
         description: error.message || "Something went wrong",
       });
+    } else {
+      window.location.href = "/";
     }
 
     return { error };


### PR DESCRIPTION
## Summary
- ensure logout navigates back to `/`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871ca2ba038832899a871750a8db198

## Resumo por Sourcery

Melhorias:
- Adiciona redirecionamento para '/' após o logout bem-sucedido em SupabaseAuthContext

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add redirect to '/' on successful sign out in SupabaseAuthContext

</details>