### PR TITLE
Alterar layout de GameScreen

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -108,6 +108,19 @@ const GameScreen = () => {
     return <Navigate to="/" />;
   }
 
+  const oddPlayers = playerScores
+    ? Object.keys(playerScores)
+        .map((id) => parseInt(id, 10))
+        .filter((id) => id % 2 === 1)
+        .sort((a, b) => a - b)
+    : [];
+  const evenPlayers = playerScores
+    ? Object.keys(playerScores)
+        .map((id) => parseInt(id, 10))
+        .filter((id) => id % 2 === 0)
+        .sort((a, b) => a - b)
+    : [];
+
   return (
     <>
     <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-4">
@@ -116,23 +129,34 @@ const GameScreen = () => {
         <TeamScore team="white" score={teamScores.white} label="EQUIPE BRANCA" />
       </div>
 
-      <div className="flex-1 flex items-center justify-center">
-        <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimerClick} />
-      </div>
-
-      <div className="grid grid-cols-5 grid-rows-2 gap-2 sm:gap-3 h-28 sm:h-32">
-        {playerScores && Object.keys(playerScores).map((pId) => {
-          const playerId = parseInt(pId, 10);
-          return (
+      <div className="flex flex-1 items-center justify-center gap-2 sm:gap-4">
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {oddPlayers.map((playerId) => (
             <PlayerScore
               key={playerId}
               playerId={playerId}
               score={playerScores[playerId]}
-              isRedTeam={playerId % 2 === 1}
+              isRedTeam={true}
               onClick={() => handlePlayerScoreUpdate(playerId)}
             />
-          );
-        })}
+          ))}
+        </div>
+
+        <div className="flex-1 flex items-center justify-center">
+          <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimerClick} />
+        </div>
+
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {evenPlayers.map((playerId) => (
+            <PlayerScore
+              key={playerId}
+              playerId={playerId}
+              score={playerScores[playerId]}
+              isRedTeam={false}
+              onClick={() => handlePlayerScoreUpdate(playerId)}
+            />
+          ))}
+        </div>
       </div>
 
       {isCaptain && (


### PR DESCRIPTION
## Summary
- reorganize GameScreen layout so player scores are shown on the sides

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68758c9028a883289eddba8373f99169