### PR TITLE
Ajustar dimensões dos quadros de jogadores

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -108,6 +108,19 @@ const GameScreen = () => {
     return <Navigate to="/" />;
   }
 
+  const oddPlayers = playerScores
+    ? Object.keys(playerScores)
+        .map((id) => parseInt(id, 10))
+        .filter((id) => id % 2 === 1)
+        .sort((a, b) => a - b)
+    : [];
+  const evenPlayers = playerScores
+    ? Object.keys(playerScores)
+        .map((id) => parseInt(id, 10))
+        .filter((id) => id % 2 === 0)
+        .sort((a, b) => a - b)
+    : [];
+
   return (
     <>
     <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-4">
@@ -116,23 +129,34 @@ const GameScreen = () => {
         <TeamScore team="white" score={teamScores.white} label="EQUIPE BRANCA" />
       </div>
 
-      <div className="flex-1 flex items-center justify-center">
-        <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimerClick} />
-      </div>
-
-      <div className="grid grid-cols-5 grid-rows-2 gap-2 sm:gap-3 h-28 sm:h-32">
-        {playerScores && Object.keys(playerScores).map((pId) => {
-          const playerId = parseInt(pId, 10);
-          return (
+      <div className="flex flex-1 items-center justify-center gap-2 sm:gap-4">
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {oddPlayers.map((playerId) => (
             <PlayerScore
               key={playerId}
               playerId={playerId}
               score={playerScores[playerId]}
-              isRedTeam={playerId % 2 === 1}
+              isRedTeam={true}
               onClick={() => handlePlayerScoreUpdate(playerId)}
             />
-          );
-        })}
+          ))}
+        </div>
+
+        <div className="flex-1 flex items-center justify-center">
+          <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimerClick} />
+        </div>
+
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {evenPlayers.map((playerId) => (
+            <PlayerScore
+              key={playerId}
+              playerId={playerId}
+              score={playerScores[playerId]}
+              isRedTeam={false}
+              onClick={() => handlePlayerScoreUpdate(playerId)}
+            />
+          ))}
+        </div>
       </div>
 
       {isCaptain && (

--- a/src/components/PlayerScore.jsx
+++ b/src/components/PlayerScore.jsx
@@ -5,10 +5,10 @@ import { motion } from 'framer-motion';
 const PlayerScore = ({ playerId, score, isRedTeam, onClick }) => {
   return (
     <motion.div
-      className={`rounded-lg cursor-pointer select-none flex flex-col items-center justify-center transition-all duration-200 ${
-        isRedTeam 
-          ? 'bg-red-600 text-white hover:bg-red-500 active:bg-red-700' 
-          : 'bg-white text-black border-2 border-gray-300 hover:bg-gray-50 active:bg-gray-200'
+      className={`rounded-lg border-2 box-border aspect-square w-full cursor-pointer select-none flex flex-col items-center justify-center transition-all duration-200 ${
+        isRedTeam
+          ? 'bg-red-600 text-white border-red-700 hover:bg-red-500 active:bg-red-700'
+          : 'bg-white text-black border-gray-300 hover:bg-gray-50 active:bg-gray-200'
       }`}
       onClick={onClick}
       whileTap={{ scale: 0.95 }}
@@ -32,3 +32,4 @@ const PlayerScore = ({ playerId, score, isRedTeam, onClick }) => {
 };
 
 export default PlayerScore;
+


### PR DESCRIPTION
## Summary
- ensure player boxes have consistent size by adding border and aspect-square

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68758c9028a883289eddba8373f99169

## Resumo por Sourcery

Reorganiza o layout da pontuação do jogador em duas colunas verticais em torno do cronômetro e impõe dimensões quadradas consistentes para as caixas dos jogadores

Melhorias:
- Calcula IDs de jogadores ímpares e pares e renderiza-os em grades separadas à esquerda/direita, flanqueando o cronômetro
- Atualiza o estilo do componente PlayerScore para incluir border, box-border, aspect-square e full-width, e refina as cores da borda da equipe

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rearrange player score layout into two vertical columns around the timer and enforce consistent square dimensions for player boxes

Enhancements:
- Compute odd and even player IDs and render them in separate left/right grids flanking the timer
- Update PlayerScore component styling to include border, box-border, aspect-square, and full-width, and refine team border colors

</details>