### PR TITLE
Ajustar layout do placar mobile

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -108,31 +108,55 @@ const GameScreen = () => {
     return <Navigate to="/" />;
   }
 
+  const oddPlayers = playerScores
+    ? Object.keys(playerScores)
+        .map((id) => parseInt(id, 10))
+        .filter((id) => id % 2 === 1)
+        .sort((a, b) => a - b)
+    : [];
+  const evenPlayers = playerScores
+    ? Object.keys(playerScores)
+        .map((id) => parseInt(id, 10))
+        .filter((id) => id % 2 === 0)
+        .sort((a, b) => a - b)
+    : [];
+
   return (
     <>
-    <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-4">
-      <div className="flex gap-2 sm:gap-4 h-16 sm:h-20">
+    <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-2">
+      <div className="flex gap-2 sm:gap-4 h-14 sm:h-16">
         <TeamScore team="red" score={teamScores.red} label="EQUIPE VERMELHA" />
         <TeamScore team="white" score={teamScores.white} label="EQUIPE BRANCA" />
       </div>
 
-      <div className="flex-1 flex items-center justify-center">
-        <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimerClick} />
-      </div>
-
-      <div className="grid grid-cols-5 grid-rows-2 gap-2 sm:gap-3 h-28 sm:h-32">
-        {playerScores && Object.keys(playerScores).map((pId) => {
-          const playerId = parseInt(pId, 10);
-          return (
+      <div className="flex flex-1 items-center justify-center gap-2 sm:gap-4">
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {oddPlayers.map((playerId) => (
             <PlayerScore
               key={playerId}
               playerId={playerId}
               score={playerScores[playerId]}
-              isRedTeam={playerId % 2 === 1}
+              isRedTeam={true}
               onClick={() => handlePlayerScoreUpdate(playerId)}
             />
-          );
-        })}
+          ))}
+        </div>
+
+        <div className="flex-1 flex items-center justify-center">
+          <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimerClick} />
+        </div>
+
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {evenPlayers.map((playerId) => (
+            <PlayerScore
+              key={playerId}
+              playerId={playerId}
+              score={playerScores[playerId]}
+              isRedTeam={false}
+              onClick={() => handlePlayerScoreUpdate(playerId)}
+            />
+          ))}
+        </div>
       </div>
 
       {isCaptain && (

--- a/src/components/PlayerScore.jsx
+++ b/src/components/PlayerScore.jsx
@@ -5,10 +5,10 @@ import { motion } from 'framer-motion';
 const PlayerScore = ({ playerId, score, isRedTeam, onClick }) => {
   return (
     <motion.div
-      className={`rounded-lg cursor-pointer select-none flex flex-col items-center justify-center transition-all duration-200 ${
-        isRedTeam 
-          ? 'bg-red-600 text-white hover:bg-red-500 active:bg-red-700' 
-          : 'bg-white text-black border-2 border-gray-300 hover:bg-gray-50 active:bg-gray-200'
+      className={`rounded-lg border-2 box-border aspect-square w-full cursor-pointer select-none flex flex-col items-center justify-center transition-all duration-200 ${
+        isRedTeam
+          ? 'bg-red-600 text-white border-red-700 hover:bg-red-500 active:bg-red-700'
+          : 'bg-white text-black border-gray-300 hover:bg-gray-50 active:bg-gray-200'
       }`}
       onClick={onClick}
       whileTap={{ scale: 0.95 }}
@@ -32,3 +32,4 @@ const PlayerScore = ({ playerId, score, isRedTeam, onClick }) => {
 };
 
 export default PlayerScore;
+

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -37,7 +37,7 @@ const Timer = ({ timeLeft, gameState, onClick }) => {
       <div className="absolute inset-0 rounded-full bg-yellow-400 opacity-20 blur-xl animate-pulse" />
       
       {/* Main timer circle */}
-      <div className="relative w-64 h-64 sm:w-80 sm:h-80 flex items-center justify-center">
+      <div className="relative w-56 h-56 sm:w-72 sm:h-72 flex items-center justify-center">
         {/* Background circle */}
         <svg className="absolute w-full h-full transform -rotate-90" viewBox="0 0 320 320">
           <circle
@@ -72,7 +72,7 @@ const Timer = ({ timeLeft, gameState, onClick }) => {
         {/* Timer display */}
         <div className="relative z-10 text-center">
           <motion.div
-            className={`timer-font text-7xl font-bold ${
+            className={`timer-font text-6xl sm:text-7xl font-bold ${
               isCriticalTime ? 'text-red-400' : isLowTime ? 'text-yellow-300' : 'text-yellow-400'
             }`}
             animate={isCriticalTime && gameState === 'running' ? { 

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -58,32 +58,53 @@ const HomeScreen = () => {
     }
   }, [timeLeft, status, playSound]);
 
+  const oddPlayers = Object.keys(playerScores)
+    .map((id) => parseInt(id, 10))
+    .filter((id) => id % 2 === 1)
+    .sort((a, b) => a - b);
+  const evenPlayers = Object.keys(playerScores)
+    .map((id) => parseInt(id, 10))
+    .filter((id) => id % 2 === 0)
+    .sort((a, b) => a - b);
+
   return (
-    <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-4">
+    <div className="min-h-screen w-screen overflow-y-auto bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col p-2 sm:p-4 gap-2">
       <header className="flex justify-between items-center text-white mb-2">
         <h1 className="text-xl font-bold">Gateball Timer</h1>
         <Button variant="ghost" className="text-yellow-400" onClick={() => navigate('/auth')}>Equipe</Button>
       </header>
-      <div className="flex gap-2 sm:gap-4 h-16 sm:h-20">
+      <div className="flex gap-2 sm:gap-4 h-14 sm:h-16">
         <TeamScore team="red" score={teamScores.red} label="EQUIPE VERMELHA" />
         <TeamScore team="white" score={teamScores.white} label="EQUIPE BRANCA" />
       </div>
-      <div className="flex-1 flex items-center justify-center">
-        <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimer} />
-      </div>
-      <div className="grid grid-cols-5 grid-rows-2 gap-2 sm:gap-3 h-28 sm:h-32">
-        {Object.keys(playerScores).map(pId => {
-          const id = parseInt(pId, 10);
-          return (
+      <div className="flex flex-1 items-center justify-center gap-2 sm:gap-4">
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {oddPlayers.map((id) => (
             <PlayerScore
               key={id}
               playerId={id}
               score={playerScores[id]}
-              isRedTeam={id % 2 === 1}
+              isRedTeam={true}
               onClick={() => updatePlayerScore(id)}
             />
-          );
-        })}
+          ))}
+        </div>
+
+        <div className="flex-1 flex items-center justify-center">
+          <Timer timeLeft={timeLeft} gameState={status} onClick={handleTimer} />
+        </div>
+
+        <div className="grid grid-rows-5 gap-2 sm:gap-3 w-16 sm:w-20">
+          {evenPlayers.map((id) => (
+            <PlayerScore
+              key={id}
+              playerId={id}
+              score={playerScores[id]}
+              isRedTeam={false}
+              onClick={() => updatePlayerScore(id)}
+            />
+          ))}
+        </div>
       </div>
       <div className="flex justify-center gap-2 sm:gap-4 h-10 sm:h-12">
         <Button variant="outline" size="sm" onClick={handleTimer} className="bg-gray-800 border-gray-600 text-white hover:bg-gray-700">


### PR DESCRIPTION
## Summary
- reduce timer font size on mobile in `Timer.jsx`
- update player cards to have fixed square shape in `PlayerScore.jsx`
- show odd players on the left and even players on the right of the timer in `GameScreen.jsx`
- apply the same layout to `HomeScreen.jsx`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68758c9028a883289eddba8373f99169

## Resumo por Sourcery

Ajuste no layout do placar para dispositivos móveis

Melhorias:
- Redução do tamanho do componente do cronômetro e da fonte em telas de dispositivos móveis
- Imposição de um formato quadrado fixo para os cards dos jogadores
- Reorganização dos cards dos jogadores para exibir os jogadores com índice ímpar à esquerda e os jogadores com índice par à direita do cronômetro
- Aplicação da estrutura de layout e espaçamento atualizados tanto para `GameScreen` quanto para `HomeScreen`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust mobile scoreboard layout

Enhancements:
- Reduce timer component size and font on mobile screens
- Enforce fixed square shape for player cards
- Reorganize player cards to display odd-indexed players on the left and even-indexed players on the right of the timer
- Apply the updated layout structure and spacing to both GameScreen and HomeScreen

</details>