### PR TITLE
Add double tap out marker

### DIFF
--- a/src/components/CreateGameDialog.jsx
+++ b/src/components/CreateGameDialog.jsx
@@ -65,11 +65,16 @@ const CreateGameDialog = () => {
 
       // 5. Create Game with initial state
       const initialScores = {};
-      for (let i = 1; i <= 10; i++) initialScores[i] = 0;
+      const initialOuts = {};
+      for (let i = 1; i <= 10; i++) {
+        initialScores[i] = 0;
+        initialOuts[i] = false;
+      }
       const initialGameState = {
         status: 'lobby',
         timeLeft: 1800,
         scores: initialScores,
+        outs: initialOuts,
       };
 
       const { data: gameData, error: gameError } = await supabase

--- a/src/components/PlayerScore.jsx
+++ b/src/components/PlayerScore.jsx
@@ -2,7 +2,7 @@
 import React, { memo, useMemo } from 'react';
 import { motion } from 'framer-motion';
 
-const PlayerScore = memo(({ playerId, score, isRedTeam, onClick }) => {
+const PlayerScore = memo(({ playerId, score, isRedTeam, isOut = false, onClick }) => {
   const buttonClasses = useMemo(() => {
     return `rounded-lg border-2 box-border aspect-square w-full cursor-pointer select-none flex flex-col items-center justify-center transition-all duration-200 ${
       isRedTeam
@@ -19,8 +19,9 @@ const PlayerScore = memo(({ playerId, score, isRedTeam, onClick }) => {
       whileHover={{ scale: 1.02 }}
       layout
     >
-      <div className="text-xs font-medium opacity-90">
-        Jogador {playerId}
+      <div className="text-xs font-medium opacity-90 flex items-center gap-1">
+        <span>Jogador {playerId}</span>
+        {isOut && <span className="text-yellow-200 text-[10px] font-bold">OUT</span>}
       </div>
       <motion.div
         className="score-font text-2xl font-bold"

--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -84,12 +84,17 @@ export const useGameState = (gameId) => {
   const resetGame = useCallback(() => {
     if (!isCaptain) return;
     const initialScores = {};
-    for (let i = 1; i <= 10; i++) initialScores[i] = 0;
-    
+    const initialOuts = {};
+    for (let i = 1; i <= 10; i++) {
+      initialScores[i] = 0;
+      initialOuts[i] = false;
+    }
+
     const newState = {
       status: 'lobby',
       timeLeft: 1800,
-      scores: initialScores
+      scores: initialScores,
+      outs: initialOuts,
     };
     updateRemoteState(newState);
   }, [updateRemoteState, isCaptain]);
@@ -112,6 +117,14 @@ export const useGameState = (gameId) => {
 
     const newScores = { ...gameState.scores, [playerId]: newScore };
     const newState = { ...gameState, scores: newScores };
+    updateRemoteState(newState);
+  }, [gameState, updateRemoteState, isCaptain]);
+
+  const togglePlayerOut = useCallback((playerId) => {
+    if (!gameState || !isCaptain) return;
+    const current = gameState.outs?.[playerId] || false;
+    const newOuts = { ...gameState.outs, [playerId]: !current };
+    const newState = { ...gameState, outs: newOuts };
     updateRemoteState(newState);
   }, [gameState, updateRemoteState, isCaptain]);
 
@@ -208,9 +221,11 @@ export const useGameState = (gameId) => {
     pauseGame,
     resetGame,
     updatePlayerScore,
+    togglePlayerOut,
     finishGame,
     status: gameState?.status,
     timeLeft: gameState?.timeLeft,
     playerScores: gameState?.scores,
+    playerOuts: gameState?.outs,
   };
 };

--- a/src/hooks/useLocalGame.js
+++ b/src/hooks/useLocalGame.js
@@ -6,10 +6,17 @@ const initScores = () => {
   return s;
 };
 
+const initOuts = () => {
+  const o = {};
+  for (let i = 1; i <= 10; i++) o[i] = false;
+  return o;
+};
+
 export const useLocalGame = () => {
   const [status, setStatus] = useState('lobby');
   const [timeLeft, setTimeLeft] = useState(1800);
   const [scores, setScores] = useState(initScores);
+  const [outs, setOuts] = useState(initOuts);
   const timerRef = useRef(null);
 
   const teamScores = {
@@ -29,6 +36,7 @@ export const useLocalGame = () => {
     setStatus('lobby');
     setTimeLeft(1800);
     setScores(initScores());
+    setOuts(initOuts());
   }, []);
 
   const updatePlayerScore = useCallback((playerId) => {
@@ -38,6 +46,10 @@ export const useLocalGame = () => {
       const next = current === 5 ? 0 : sequence[(sequence.indexOf(current) + 1) % sequence.length];
       return { ...prev, [playerId]: next };
     });
+  }, []);
+
+  const togglePlayerOut = useCallback((playerId) => {
+    setOuts(prev => ({ ...prev, [playerId]: !prev[playerId] }));
   }, []);
 
   useEffect(() => {
@@ -62,5 +74,7 @@ export const useLocalGame = () => {
     pauseGame,
     resetGame,
     updatePlayerScore,
+    togglePlayerOut,
+    playerOuts: outs,
   };
 };

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -13,15 +13,18 @@ const HomeScreen = () => {
     status,
     timeLeft,
     playerScores,
+    playerOuts,
     teamScores,
     startGame,
     pauseGame,
     resetGame,
-    updatePlayerScore
+    updatePlayerScore,
+    togglePlayerOut
   } = useLocalGame();
 
   const { playSound, initializeAudio } = useAudioManager();
   const [isAudioInitialized, setIsAudioInitialized] = useState(false);
+  const [playerTapTimes, setPlayerTapTimes] = useState({});
 
   const handleFirstInteraction = useCallback(async () => {
     if (!isAudioInitialized) {
@@ -58,6 +61,18 @@ const HomeScreen = () => {
     }
   }, [timeLeft, status, playSound]);
 
+  const handlePlayerScore = useCallback(async (id) => {
+    await handleFirstInteraction();
+    const now = Date.now();
+    const last = playerTapTimes[id] || 0;
+    if (now - last < 300) {
+      togglePlayerOut(id);
+    } else {
+      updatePlayerScore(id);
+    }
+    setPlayerTapTimes((prev) => ({ ...prev, [id]: now }));
+  }, [playerTapTimes, updatePlayerScore, togglePlayerOut, handleFirstInteraction]);
+
   const oddPlayers = Object.keys(playerScores)
     .map((id) => parseInt(id, 10))
     .filter((id) => id % 2 === 1)
@@ -85,7 +100,8 @@ const HomeScreen = () => {
               playerId={id}
               score={playerScores[id]}
               isRedTeam={true}
-              onClick={() => updatePlayerScore(id)}
+              isOut={playerOuts?.[id]}
+              onClick={() => handlePlayerScore(id)}
             />
           ))}
         </div>
@@ -101,7 +117,8 @@ const HomeScreen = () => {
               playerId={id}
               score={playerScores[id]}
               isRedTeam={false}
-              onClick={() => updatePlayerScore(id)}
+              isOut={playerOuts?.[id]}
+              onClick={() => handlePlayerScore(id)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- support OUT marker for each player
- initialize `outs` field when creating games
- update local and remote game hooks to manage outs
- allow toggling OUT with double taps in player score components

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877b5bb48cc8328a7545600828a9f07